### PR TITLE
优化农业银行信用卡公众号规则匹配

### DIFF
--- a/src/rule/com.tencent.mm/app/微信公众号农业银行信用卡/main.js
+++ b/src/rule/com.tencent.mm/app/微信公众号农业银行信用卡/main.js
@@ -26,6 +26,26 @@ const rules = [
       )
     },
   ],
+  // 收入规则（新增的返现场景）
+  [
+    /交易时间：(.*?)\n交易类型：卡号尾号（(\d+)），刷卡金转入\n交易金额：([\d,]+.\d{2})元\n可用余额：.*?元\n交易地址：(.*?),消费时间.*$/,
+    match => {
+      const [, time, number, money, description] = match;
+
+      return new RuleObject(
+        BillType.Income,  // 收入类型
+        toFloat(money),
+        SOURCE,
+        description,     // 描述（如：天天返现）
+        `${SOURCE}(${number})`,
+        '',
+        0.0,
+        Currency['人民币'],
+        formatDate(time, 'Y-M-D h:i:s'),
+        `返现[${SOURCE}-收入]`
+      )
+    },
+  ],
 ];
 
 

--- a/src/rule/com.tencent.mm/app/微信公众号农业银行信用卡/main.js
+++ b/src/rule/com.tencent.mm/app/微信公众号农业银行信用卡/main.js
@@ -6,8 +6,9 @@ const TITLE = ['交易成功通知'];
 
 // 正则表达式和处理函数的映射关系
 const rules = [
+  // 支出规则（原有的网上支付场景）
   [
-    /交易时间：(.*?)\n交易类型：卡号尾号（(\d+)），网上支付\n交易金额：([\d,]+.\d{2})元\n可用余额：.*?元\n交易地址：(.*?)-(.*?)$/,
+    /交易时间：(.*?)\n交易类型：卡号尾号（(\d+)），网上支付\n交易金额：([\d,]+.\d{2})元\n可用余额：.*?元\n交易地址：(.*?)，(.*?)$/,
     match => {
       const [, time, number, money, shopName, shopItem] = match;
 
@@ -21,7 +22,7 @@ const rules = [
         0.0,
         Currency['人民币'],
         formatDate(time, 'Y-M-D h:i:s'),
-        `微信[${SOURCE}-消费]`
+        `${shopName}[${SOURCE}-消费]`
       )
     },
   ],


### PR DESCRIPTION
- 修复微信-农业银行信用卡公众号-消费场景匹配失败的问题 https://github.com/AutoAccountingOrg/AutoRule/issues/512
- 新增微信-农业银行信用卡公众号-刷卡金返现场景匹配规则https://github.com/AutoAccountingOrg/AutoRule/issues/511